### PR TITLE
 feat: add function on tap chip at detail book

### DIFF
--- a/lib/presentation/viewmodels/books_by_topic_viewmodel.dart
+++ b/lib/presentation/viewmodels/books_by_topic_viewmodel.dart
@@ -1,0 +1,26 @@
+import 'package:circe/data/datasources/book_api_service.dart';
+import 'package:circe/data/models/book_model.dart';
+import 'package:circe/data/models/book_query_params.dart';
+import 'package:circe/data/models/book_response_model.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class BooksByTopicViewmodel extends StateNotifier<AsyncValue<List<BookModel>>> {
+  final BookApiService _service = BookApiService();
+
+  BooksByTopicViewmodel(String topic) : super(const AsyncLoading()) {
+    _fetchBooksByTopic(topic);
+  }
+
+  Future<void> _fetchBooksByTopic(String topic) async {
+    try {
+      final BookResponseModel books = await _service.fetchBooks(
+        query: BookQueryParams(
+          topic: topic,
+        ),
+      );
+      state = AsyncData(books.results);
+    } catch (e) {
+      state = AsyncError(e, StackTrace.current);
+    }
+  }
+}

--- a/lib/presentation/views/book_detail_view.dart
+++ b/lib/presentation/views/book_detail_view.dart
@@ -1,5 +1,6 @@
 import 'package:circe/data/models/book_model.dart';
 import 'package:circe/presentation/viewmodels/saved_books_provider.dart';
+import 'package:circe/presentation/views/books_by_subject_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -51,7 +52,27 @@ class BookDetailView extends ConsumerWidget {
             const SizedBox(height: 24),
             Wrap(
               spacing: 8,
-              children: book.subjects.map((s) => Chip(label: Text(s))).toList(),
+              children: book.subjects
+                  .map(
+                    (String subject) => ActionChip(
+                      label: Text(subject),
+                      onPressed: () {
+                        final String firstWord = subject
+                            .split(' ')
+                            .first
+                            .replaceAll(RegExp(r'[^\w\s]'), '');
+
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) =>
+                                BooksBySubjectView(subject: firstWord),
+                          ),
+                        );
+                      },
+                    ),
+                  )
+                  .toList(),
             ),
           ],
         ),

--- a/lib/presentation/views/books_by_subject_view.dart
+++ b/lib/presentation/views/books_by_subject_view.dart
@@ -1,0 +1,71 @@
+import 'package:circe/data/models/book_model.dart';
+import 'package:circe/data/models/book_query_params.dart';
+import 'package:circe/presentation/viewmodels/book_list_viewmodel.dart';
+import 'package:circe/presentation/views/book_detail_view.dart';
+import 'package:circe/presentation/widgets/book_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class BooksBySubjectView extends ConsumerStatefulWidget {
+  final String? subject;
+
+  const BooksBySubjectView({
+    super.key,
+    required this.subject,
+  });
+
+  @override
+  ConsumerState<BooksBySubjectView> createState() => _BooksBySubjectViewState();
+}
+
+class _BooksBySubjectViewState extends ConsumerState<BooksBySubjectView> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(
+      () {
+        ref.read(bookListProvider.notifier).setQuery(
+              query: BookQueryParams(
+                topic: widget.subject,
+              ),
+            );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AsyncValue<List<BookModel>> booksState = ref.watch(bookListProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Books: ${widget.subject}'),
+      ),
+      body: booksState.when(
+        data: (books) => books.isEmpty
+            ? const Center(child: Text('No books found.'))
+            : GridView.builder(
+                padding: const EdgeInsets.all(8),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  mainAxisExtent: 250,
+                  crossAxisSpacing: 12,
+                  mainAxisSpacing: 12,
+                ),
+                itemCount: books.length,
+                itemBuilder: (_, i) => BookCard(
+                  book: books[i],
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => BookDetailView(book: books[i]),
+                    ),
+                  ),
+                ),
+              ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(child: Text('Error: $err')),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Add new function on tap chip at detail book

View things need to improve in the future : 

1. Currently the function only search first word as the topic from book subject , need to consider to make it can combine all the words. This happen because of the API limitation, here the link to the [documentation](http://gutendex.com/#:~:text=number%20of%20downloads.-,topic,-Use%20this%20to) 
2. Need to make the chip scroll to side instead of long list to the bottom